### PR TITLE
Convert chart values to helmChartConfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.5
 	github.com/imdario/mergo v0.3.16
 	github.com/jaypipes/ghw v0.12.0
+	github.com/k3s-io/helm-controller v0.16.4
 	github.com/llmos-ai/llmos/utils v0.0.0
 	github.com/mudler/yip v1.5.0
 	github.com/onsi/ginkgo/v2 v2.19.0

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQ
 github.com/gookit/color v1.5.0/go.mod h1:43aQb+Zerm/BWh2GnrgOQm7ffz7tvQXEKV6BFMl7wAo=
 github.com/gookit/color v1.5.4 h1:FZmqs7XOyGgCAxmWyPslpiok1k05wmY3SJTytgvYFs0=
 github.com/gookit/color v1.5.4/go.mod h1:pZJOeOS8DM43rXbp4AZo1n9zCU2qjpcRko0b6/QJi9w=
-github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
-github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
@@ -207,6 +207,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/k3s-io/helm-controller v0.16.4 h1:l1noZJacLT2C9JUgfwO9SV8XtfAv1J9avVXyzv8tYHo=
+github.com/k3s-io/helm-controller v0.16.4/go.mod h1:AcSxEhOIUgeVvBTnJOAwcezBZXtYew/RhKwO5xp3RlM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=

--- a/pkg/bootstrap/llmos-operator/run.go
+++ b/pkg/bootstrap/llmos-operator/run.go
@@ -3,14 +3,24 @@ package operator
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
 
+	helmv1 "github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1"
+	cmd2 "github.com/llmos-ai/llmos/utils/cmd"
 	"github.com/llmos-ai/llmos/utils/data"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/llmos-ai/llmos/pkg/applyinator"
 	"github.com/llmos-ai/llmos/pkg/bootstrap/config"
 	"github.com/llmos-ai/llmos/pkg/bootstrap/images"
 	"github.com/llmos-ai/llmos/pkg/bootstrap/kubectl"
+	"github.com/llmos-ai/llmos/pkg/constants"
+)
+
+const (
+	helmAPIVersion     = "helm.cattle.io/v1"
+	helmConfigKindName = "HelmChartConfig"
 )
 
 var defaultValues = map[string]interface{}{
@@ -25,8 +35,8 @@ var defaultValues = map[string]interface{}{
 	},
 }
 
-func GetOperatorValues(dataDir string) string {
-	return fmt.Sprintf("%s/llmos-operator/values.yaml", dataDir)
+func GetOperatorChartConfigPath(dataDir string) string {
+	return fmt.Sprintf("%s/charts/llmos-operator-config.yaml", dataDir)
 }
 
 func ToFile(cfg *config.Config, dataDir string) (*applyinator.File, error) {
@@ -37,23 +47,57 @@ func ToFile(cfg *config.Config, dataDir string) (*applyinator.File, error) {
 	})
 	values = data.MergeMaps(values, cfg.LLMOSOperatorValues)
 
-	data, err := yaml.Marshal(values)
+	valuesData, err := yaml.Marshal(values)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling llmos-operator values.yaml: %w", err)
 	}
 
+	config := helmv1.HelmChartConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: helmAPIVersion,
+			Kind:       helmConfigKindName,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.LLMOSOperatorName,
+			Namespace: constants.SystemNamespace,
+		},
+		Spec: helmv1.HelmChartConfigSpec{
+			ValuesContent: string(valuesData),
+		},
+	}
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling llmos-operator HelmChartConfig: %w", err)
+	}
+
 	return &applyinator.File{
 		Content: base64.StdEncoding.EncodeToString(data),
-		Path:    GetOperatorValues(dataDir),
+		Path:    GetOperatorChartConfigPath(dataDir),
 	}, nil
 }
 
-func ToInstruction(imageOverride, systemDefaultRegistry, k8sVersion, operatorVersion, dataDir string) (*applyinator.OneTimeInstruction, error) {
+func ToInstruction(imageOverride, systemDefaultRegistry, k8sVersion, operatorVersion string) (*applyinator.OneTimeInstruction, error) {
 	return &applyinator.OneTimeInstruction{
 		CommonInstruction: applyinator.CommonInstruction{
 			Name:  "install-llmos-operator",
 			Image: images.GetLLMOSInstallerImage(imageOverride, systemDefaultRegistry, operatorVersion),
-			Env:   append(kubectl.Env(k8sVersion), fmt.Sprintf("LLMOS_OPERATOR_VALUES=%s", GetOperatorValues(dataDir))),
+			Env:   kubectl.Env(k8sVersion),
+		},
+		SaveOutput: true,
+	}, nil
+}
+
+func ToChartConfigInstruction(k8sVersion, dataDir string) (*applyinator.OneTimeInstruction, error) {
+	file := GetOperatorChartConfigPath(dataDir)
+	cmd, err := cmd2.Self()
+	if err != nil {
+		return nil, fmt.Errorf("resolving location of %s: %w", os.Args[0], err)
+	}
+	return &applyinator.OneTimeInstruction{
+		CommonInstruction: applyinator.CommonInstruction{
+			Name:    "apply-operator-chart-config",
+			Args:    []string{"retry", kubectl.Command(k8sVersion), "apply", "-f", file},
+			Command: cmd,
 		},
 		SaveOutput: true,
 	}, nil

--- a/pkg/bootstrap/llmos-operator/run.go
+++ b/pkg/bootstrap/llmos-operator/run.go
@@ -16,7 +16,11 @@ import (
 var defaultValues = map[string]interface{}{
 	"operator": map[string]interface{}{
 		"apiserver": map[string]interface{}{
-			"replicaCount": 1,
+			"service": map[string]interface{}{
+				"type":          "LoadBalancer",
+				"httpsPort":     8443,
+				"httpsNodePort": 30443,
+			},
 		},
 	},
 }

--- a/pkg/bootstrap/plan/bootstrap.go
+++ b/pkg/bootstrap/plan/bootstrap.go
@@ -117,10 +117,21 @@ func (p *plan) addInstructions(cfg *config.Config, dataDir string, initRole bool
 			return err
 		}
 
-		if err := p.addInstruction(operator.ToInstruction(cfg.LLMOSInstallerImage, cfg.GlobalImageRegistry, k8sVersion, operatorVersion, dataDir)); err != nil {
+		// add resource instruction
+		if err := p.addInstruction(manifest.ToInstruction(cfg.RuntimeInstallerImage, cfg.GlobalImageRegistry, k8sVersion, dataDir)); err != nil {
 			return err
 		}
 
+		// add operator chart config instruction
+		if err := p.addInstruction(operator.ToChartConfigInstruction(k8sVersion, dataDir)); err != nil {
+			return err
+		}
+
+		if err := p.addInstruction(operator.ToInstruction(cfg.LLMOSInstallerImage, cfg.GlobalImageRegistry, k8sVersion, operatorVersion)); err != nil {
+			return err
+		}
+
+		// add operator wait instructions
 		if err := p.addInstruction(operator.ToWaitOperatorInstruction(k8sVersion)); err != nil {
 			return err
 		}
@@ -130,11 +141,6 @@ func (p *plan) addInstructions(cfg *config.Config, dataDir string, initRole bool
 		}
 
 		if err := p.addInstruction(operator.ToWaitSUCInstruction(cfg.LLMOSInstallerImage, cfg.GlobalImageRegistry, k8sVersion)); err != nil {
-			return err
-		}
-
-		// add resource instruction
-		if err := p.addInstruction(manifest.ToInstruction(cfg.RuntimeInstallerImage, cfg.GlobalImageRegistry, k8sVersion, dataDir)); err != nil {
 			return err
 		}
 	}

--- a/pkg/bootstrap/plan/run.go
+++ b/pkg/bootstrap/plan/run.go
@@ -53,7 +53,7 @@ func RunWithKubernetesVersion(ctx context.Context, cfg *config.Config, k8sVersio
 	if err != nil {
 		return fmt.Errorf("failed to apply plan: %w", err)
 	} else if !output.OneTimeApplySucceeded {
-		logrus.Fatalf("failed to apply plan, please check your network connectivity.")
+		return fmt.Errorf("kubernetes runtime plan is not applied successfully, please check log for more detials")
 	}
 
 	return saveOutput(output.OneTimeOutput, dataDir)

--- a/pkg/bootstrap/run.go
+++ b/pkg/bootstrap/run.go
@@ -113,7 +113,7 @@ func (l *LLMOS) execute(ctx context.Context) error {
 		return err
 	}
 
-	logrus.Infof("Successfully Bootstrapped LLMOS (%s/%s)", operatorVersion, k8sVersion)
+	logrus.Infof("Successfully Bootstrapped LLMOS %s(%s)", operatorVersion, k8sVersion)
 	return nil
 }
 

--- a/pkg/bootstrap/runtime/config.go
+++ b/pkg/bootstrap/runtime/config.go
@@ -75,7 +75,6 @@ func ToConfig(config *config.RuntimeConfig, server string) ([]byte, error) {
 			result["cluster-init"] = "true"
 		}
 	}
-
 	logrus.Debugf("generated LLMOS config: %+v\n", result)
 	return yaml.Marshal(result)
 }

--- a/pkg/bootstrap/version/versions.go
+++ b/pkg/bootstrap/version/versions.go
@@ -147,7 +147,7 @@ func GetClusterK8sAndOperatorVersions(serverURL, token string) (string, string, 
 		return "", "", fmt.Errorf("invalid server URL: %v", err)
 	}
 
-	url := fmt.Sprintf("https://%s:%s/v1-cluster/cluster-info", parsedURL.Hostname(), "30443")
+	url := fmt.Sprintf("https://%s:%s/v1-cluster/cluster-info", parsedURL.Hostname(), "8443")
 
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 3

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -5,4 +5,7 @@ const (
 	RecoverySize = uint(8192)
 
 	CosLiveModeFile = "/run/elemental/live_mode"
+
+	LLMOSOperatorName = "llmos-operator"
+	SystemNamespace   = "llmos-system"
 )


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Description:**
1. Convert and apply operator chart values to HelmChartConfig CRD.
2. Default to use LB svc type for LLMOS installation.
