### PR TITLE
Enable etcd-expose-metrics by default

### DIFF
--- a/pkg/bootstrap/check.go
+++ b/pkg/bootstrap/check.go
@@ -34,19 +34,11 @@ func mergeConfigs(cfg Config, result config.Config) config.Config {
 
 	if result.KubernetesVersion == "" {
 		result.KubernetesVersion = cfg.KubernetesVersion
-
 	}
 
-	addDefaultConfigs(&result)
+	result.SetDefaults()
 
 	return result
-}
-
-func addDefaultConfigs(cfg *config.Config) {
-	if cfg.Labels == nil {
-		cfg.Labels = []string{}
-	}
-	cfg.Labels = append(cfg.Labels, "llmos.ai/managed=true")
 }
 
 func validateConfig(cfg *config.Config) error {

--- a/pkg/bootstrap/config/runtime.go
+++ b/pkg/bootstrap/config/runtime.go
@@ -4,6 +4,10 @@ import (
 	"strings"
 )
 
+const (
+	EtcdExposeMetrics = "etcd-expose-metrics"
+)
+
 var (
 	RuntimeRKE2    Runtime = "rke2"
 	RuntimeK3S     Runtime = "k3s"
@@ -28,6 +32,19 @@ type RuntimeConfig struct {
 	Labels          []string               `json:"labels,omitempty"`
 	Token           string                 `json:"token,omitempty"`
 	ConfigValues    map[string]interface{} `json:"extraConfig,omitempty"`
+}
+
+func (cfg *RuntimeConfig) SetDefaults() {
+	// Assign default labels
+	if cfg.Labels == nil {
+		cfg.Labels = []string{}
+	}
+	cfg.Labels = append(cfg.Labels, "llmos.ai/managed=true")
+
+	// Enable etcd metrics by default
+	if cfg.ConfigValues[EtcdExposeMetrics] == nil {
+		cfg.ConfigValues[EtcdExposeMetrics] = true
+	}
 }
 
 func GetRuntime(kubernetesVersion string) Runtime {

--- a/pkg/bootstrap/runtime/config.go
+++ b/pkg/bootstrap/runtime/config.go
@@ -76,6 +76,7 @@ func ToConfig(cfg *config.RuntimeConfig, server string) ([]byte, error) {
 			result["cluster-init"] = "true"
 		}
 	}
+
 	return yaml.Marshal(result)
 }
 


### PR DESCRIPTION
<!-- **IMPORTANT: Please do not create a Pull Request without creating an issue first.** -->

**Description:**
Enable the `etcd-expose-metrics` by default so that monitoring can fetch the metrics correctly.

**Related Issue:**
https://github.com/llmos-ai/llmos/issues/28

**Test plan:**
Add config YAML, e.g.,
```
role: cluster-init
extraConfig:
  etcd-expose-metrics: false # true or false
```
After bootstrap, verify the `/etc/rancher/k3s/config.yaml.d/40-llmos.yaml` and ` sudo cat /var/lib/rancher/k3s/server/db/etcd/config` with `advertise-client-urls` is configured correctly.


