### PR TITLE
Set k8s installer default registry to docker

### DIFF
--- a/pkg/bootstrap/images/images.go
+++ b/pkg/bootstrap/images/images.go
@@ -26,6 +26,8 @@ func GetLLMOSInstallerImage(imageOverride, registry, mirror, operatorVersion str
 func GetRuntimeInstallerImage(imageOverride, registry, mirror, kubernetesVersion string) string {
 	if registry == "" && mirror != "" {
 		registry = AliSystemDefaultRegistry
+	} else {
+		registry = "docker.io"
 	}
 
 	return getInstallerImage(imageOverride, registry, defaultRuntimeImagePrefix,


### PR DESCRIPTION
<!-- **IMPORTANT: Please do not create a Pull Request without creating an issue first.** -->

**Description:**
Set k8s installer default registry to `docker.io`
